### PR TITLE
add softhsm2 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
 		gradle \
 # other important packages
 		fuse \
+		softhsm2 \
 # clean up
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
[SoftHSM](https://wiki.opendnssec.org/display/SoftHSMDOCS/SoftHSM+Documentation+v2) provides a "virtual" SmartCard with a PKCS11 interface
